### PR TITLE
Add test user authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # PanoramaWebPoc
+
+## Credenciales de prueba
+
+El sistema incluye un usuario de prueba para acceder al módulo de inicio de sesión:
+
+- **Usuario:** `usuarioPOC`
+- **Contraseña:** `123456@`

--- a/panorama-web/src/app/pages/login/login.component.html
+++ b/panorama-web/src/app/pages/login/login.component.html
@@ -9,3 +9,4 @@
   </mat-form-field>
   <button mat-raised-button color="primary">Ingresar</button>
 </form>
+<p *ngIf="loginMessage">{{ loginMessage }}</p>

--- a/panorama-web/src/app/pages/login/login.component.ts
+++ b/panorama-web/src/app/pages/login/login.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-login',
@@ -8,9 +9,13 @@ import { Component } from '@angular/core';
 export class LoginComponent {
   username = '';
   password = '';
+  loginMessage = '';
+
+  constructor(private authService: AuthService) {}
 
   login() {
-    // Placeholder for login logic
-    console.log('Login clicked');
+    const ok = this.authService.authenticate(this.username, this.password);
+    this.loginMessage = ok ? 'Ingreso exitoso' : 'Credenciales inválidas';
+    console.log(this.loginMessage);
   }
 }

--- a/panorama-web/src/app/services/auth.service.spec.ts
+++ b/panorama-web/src/app/services/auth.service.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthService);
+  });
+
+  it('should authenticate valid user', () => {
+    expect(service.authenticate('usuarioPOC', '123456@')).toBeTrue();
+  });
+
+  it('should reject invalid user', () => {
+    expect(service.authenticate('wrong', 'credentials')).toBeFalse();
+  });
+});

--- a/panorama-web/src/app/services/auth.service.ts
+++ b/panorama-web/src/app/services/auth.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+
+interface User {
+  username: string;
+  password: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+  private readonly users: User[] = [
+    { username: 'usuarioPOC', password: '123456@' }
+  ];
+
+  authenticate(username: string, password: string): boolean {
+    return this.users.some(u => u.username === username && u.password === password);
+  }
+}

--- a/panorama-web/tsconfig.json
+++ b/panorama-web/tsconfig.json
@@ -15,6 +15,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2020",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
## Summary
- Document test login credentials in README
- Create AuthService with hardcoded test user and use it in login page
- Add unit tests for AuthService and enable TypeScript decorators

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.83 8080])*

------
https://chatgpt.com/codex/tasks/task_e_688f338951e08327b22f7e8d238ac7c2