### PR TITLE
feat: style pages and improve navigation

### DIFF
--- a/panorama-web/src/app/app.module.ts
+++ b/panorama-web/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatCardModule } from '@angular/material/card';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -42,6 +43,7 @@ import { ValidationComponent } from './pages/validation/validation.component';
     MatInputModule,
     MatSelectModule,
     MatDialogModule,
+    MatCardModule,
     AppRoutingModule
   ],
   providers: [],

--- a/panorama-web/src/app/pages/flows/flows.component.css
+++ b/panorama-web/src/app/pages/flows/flows.component.css
@@ -1,1 +1,12 @@
- table { width: 100%; }
+.flows-card {
+  margin: 20px;
+  padding: 20px;
+}
+
+table {
+  width: 100%;
+}
+
+button {
+  margin-bottom: 10px;
+}

--- a/panorama-web/src/app/pages/flows/flows.component.html
+++ b/panorama-web/src/app/pages/flows/flows.component.html
@@ -1,16 +1,19 @@
-<table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
-  <ng-container matColumnDef="id">
-    <th mat-header-cell *matHeaderCellDef>ID</th>
-    <td mat-cell *matCellDef="let element">{{ element.id }}</td>
-  </ng-container>
-  <ng-container matColumnDef="name">
-    <th mat-header-cell *matHeaderCellDef>Nombre</th>
-    <td mat-cell *matCellDef="let element">{{ element.name }}</td>
-  </ng-container>
-  <ng-container matColumnDef="status">
-    <th mat-header-cell *matHeaderCellDef>Estado</th>
-    <td mat-cell *matCellDef="let element">{{ element.status }}</td>
-  </ng-container>
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</table>
+<mat-card class="flows-card">
+  <button mat-raised-button color="primary" (click)="reload()">Refrescar</button>
+  <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+    <ng-container matColumnDef="id">
+      <th mat-header-cell *matHeaderCellDef>ID</th>
+      <td mat-cell *matCellDef="let element">{{ element.id }}</td>
+    </ng-container>
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef>Nombre</th>
+      <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+    </ng-container>
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef>Estado</th>
+      <td mat-cell *matCellDef="let element">{{ element.status }}</td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</mat-card>

--- a/panorama-web/src/app/pages/flows/flows.component.ts
+++ b/panorama-web/src/app/pages/flows/flows.component.ts
@@ -13,6 +13,10 @@ export class FlowsComponent implements OnInit {
   constructor(private flowService: FlowService) {}
 
   ngOnInit(): void {
-    this.flowService.getFlows().subscribe(flows => this.dataSource = flows);
+    this.reload();
+  }
+
+  reload() {
+    this.flowService.getFlows().subscribe(flows => (this.dataSource = flows));
   }
 }

--- a/panorama-web/src/app/pages/login/login.component.css
+++ b/panorama-web/src/app/pages/login/login.component.css
@@ -1,6 +1,11 @@
+.login-card {
+  max-width: 320px;
+  margin: 40px auto;
+  padding: 20px;
+}
+
 .login-form {
-  max-width: 300px;
-  margin: 20px auto;
   display: flex;
   flex-direction: column;
+  gap: 15px;
 }

--- a/panorama-web/src/app/pages/login/login.component.html
+++ b/panorama-web/src/app/pages/login/login.component.html
@@ -1,12 +1,15 @@
-<form (ngSubmit)="login()" class="login-form">
-  <mat-form-field appearance="fill">
-    <mat-label>Usuario</mat-label>
-    <input matInput [(ngModel)]="username" name="username">
-  </mat-form-field>
-  <mat-form-field appearance="fill">
-    <mat-label>Contraseña</mat-label>
-    <input matInput [(ngModel)]="password" name="password" type="password">
-  </mat-form-field>
-  <button mat-raised-button color="primary">Ingresar</button>
-</form>
-<p *ngIf="loginMessage">{{ loginMessage }}</p>
+<mat-card class="login-card">
+  <form (ngSubmit)="login()" class="login-form">
+    <mat-form-field appearance="fill">
+      <mat-label>Usuario</mat-label>
+      <input matInput [(ngModel)]="username" name="username" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Contraseña</mat-label>
+      <input matInput [(ngModel)]="password" name="password" type="password" />
+    </mat-form-field>
+    <button mat-raised-button color="primary">Ingresar</button>
+    <p *ngIf="loginMessage">{{ loginMessage }}</p>
+  </form>
+</mat-card>
+

--- a/panorama-web/src/app/pages/login/login.component.ts
+++ b/panorama-web/src/app/pages/login/login.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
@@ -11,11 +12,16 @@ export class LoginComponent {
   password = '';
   loginMessage = '';
 
-  constructor(private authService: AuthService) {}
+  constructor(private authService: AuthService, private router: Router) {}
 
   login() {
     const ok = this.authService.authenticate(this.username, this.password);
-    this.loginMessage = ok ? 'Ingreso exitoso' : 'Credenciales inválidas';
+    if (ok) {
+      this.loginMessage = 'Ingreso exitoso';
+      this.router.navigate(['/flujos']);
+    } else {
+      this.loginMessage = 'Credenciales inválidas';
+    }
     console.log(this.loginMessage);
   }
 }

--- a/panorama-web/src/app/pages/new-flow/new-flow.component.css
+++ b/panorama-web/src/app/pages/new-flow/new-flow.component.css
@@ -1,6 +1,11 @@
+.new-flow-card {
+  max-width: 420px;
+  margin: 40px auto;
+  padding: 20px;
+}
+
 .new-flow-form {
-  max-width: 400px;
-  margin: 20px auto;
   display: flex;
   flex-direction: column;
+  gap: 15px;
 }

--- a/panorama-web/src/app/pages/new-flow/new-flow.component.html
+++ b/panorama-web/src/app/pages/new-flow/new-flow.component.html
@@ -1,8 +1,10 @@
-<form (ngSubmit)="create()" class="new-flow-form">
-  <mat-form-field appearance="fill">
-    <mat-label>Nombre del flujo</mat-label>
-    <input matInput [(ngModel)]="flowName" name="name">
-  </mat-form-field>
-  <input type="file" (change)="onFileChange($event)">
-  <button mat-raised-button color="primary">Crear</button>
-</form>
+<mat-card class="new-flow-card">
+  <form (ngSubmit)="create()" class="new-flow-form">
+    <mat-form-field appearance="fill">
+      <mat-label>Nombre del flujo</mat-label>
+      <input matInput [(ngModel)]="flowName" name="name" />
+    </mat-form-field>
+    <input type="file" (change)="onFileChange($event)" />
+    <button mat-raised-button color="primary">Crear</button>
+  </form>
+</mat-card>

--- a/panorama-web/src/app/pages/new-flow/new-flow.component.ts
+++ b/panorama-web/src/app/pages/new-flow/new-flow.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 import { FlowService } from '../../services/flow.service';
 
 @Component({
@@ -10,7 +11,7 @@ export class NewFlowComponent {
   flowName = '';
   file?: File;
 
-  constructor(private flowService: FlowService) {}
+  constructor(private flowService: FlowService, private router: Router) {}
 
   onFileChange(event: any) {
     const files: FileList = event.target.files;
@@ -20,7 +21,10 @@ export class NewFlowComponent {
   }
 
   create() {
-    // Mock creation logic
-    this.flowService.createFlow({ name: this.flowName, file: this.file }).subscribe();
+    this.flowService
+      .createFlow({ name: this.flowName, file: this.file })
+      .subscribe(() => {
+        this.router.navigate(['/flujos']);
+      });
   }
 }

--- a/panorama-web/src/styles.css
+++ b/panorama-web/src/styles.css
@@ -1,1 +1,6 @@
-/* Add global styles here */
+/* Global styles */
+body {
+  margin: 0;
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
+  background: #f5f5f5;
+}


### PR DESCRIPTION
## Summary
- style login, new flow, and flow listing pages with Material cards
- redirect login and new flow actions to flow list and add refresh capability
- add global body styling and include MatCard module

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6892e9c4ae6c8327a5bd53628fc5c87b